### PR TITLE
Add daiquiri as the default logger

### DIFF
--- a/src/adapter_utilities.py
+++ b/src/adapter_utilities.py
@@ -11,25 +11,21 @@
 :Created:
     3/8/17
 """
-
-import logging
 import pickle
 import os
 import os.path
 from datetime import datetime
 from datetime import timedelta
 
+import daiquiri
 import d1_client.cnclient_2_0
 import requests
 
 import properties
 from adapter_exceptions import AdapterRequestFailureException
 
-logger = logging.getLogger('adapter_utilities')
-logging.basicConfig(format='%(asctime)s %(levelname)s (%(name)s): %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S%z',
-                    # filename='$NAME' + '.log',
-                    level=logging.WARN)
+
+logger = daiquiri.getLogger(__name__)
 
 
 def _is_stale_file(filename=None, seconds=None):

--- a/src/event.py
+++ b/src/event.py
@@ -13,11 +13,13 @@
 :Created:
     8/8/17
 """
-
 from datetime import datetime
 import logging
 
-logger = logging.getLogger('event')
+import daiquiri
+
+
+logger = daiquiri.getLogger(__name__)
 
 
 class Event(object):

--- a/src/lock.py
+++ b/src/lock.py
@@ -12,13 +12,15 @@
 :Created:
     3/31/17
 """
-
 import logging
 import string
 import random
 import os
 
-logger = logging.getLogger('lock')
+import daiquiri
+
+
+logger = daiquiri.getLogger(__name__)
 
 
 class Lock(object):

--- a/src/package.py
+++ b/src/package.py
@@ -13,13 +13,12 @@
 :Created:
     3/2/17
 """
-
-import logging
 import xml.etree.ElementTree as ET
+
+import daiquiri
 import d1_common.types
 import d1_common.xml
 
-from adapter_exceptions import AdapterIncompleteStateException
 import adapter_utilities
 import properties
 from resource import ResourceData
@@ -27,7 +26,8 @@ from resource import ResourceMetadata
 from resource import ResourceOre
 from resource import ResourceReport
 
-logger = logging.getLogger('package')
+
+logger = daiquiri.getLogger(__name__)
 
 
 class Package(object):

--- a/src/package_manager.py
+++ b/src/package_manager.py
@@ -13,11 +13,12 @@ from __future__ import print_function
 :Created:
     3/8/17
 """
-
 import logging
 from io import BytesIO
+import os
 import time
 
+import daiquiri
 import d1_client.cnclient_2_0
 import d1_client.mnclient_2_0
 
@@ -28,11 +29,11 @@ from package import Package
 from queue_manager import QueueManager
 
 
-logger = logging.getLogger('package_manager')
-
-# Set level to WARN to avoid verbosity in requests at INFO
-logging.basicConfig(format='%(asctime)s %(levelname)s (%(name)s): %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S%z', level=properties.LOG_LEVEL)
+cwd = os.path.dirname(os.path.realpath(__file__))
+logfile = cwd + "/package_manager.log"
+daiquiri.setup(level=logging.INFO,
+               outputs=(daiquiri.output.File(logfile), "stdout",))
+logger = daiquiri.getLogger(__name__)
 
 
 def create_gmn_client():

--- a/src/poll_manager.py
+++ b/src/poll_manager.py
@@ -15,8 +15,10 @@
 import logging
 from datetime import datetime
 from datetime import timedelta
+import os
 import xml.etree.ElementTree as ET
 
+import daiquiri
 import pendulum
 
 from adapter_exceptions import AdapterRequestFailureException
@@ -27,9 +29,11 @@ import properties
 from queue_manager import QueueManager
 
 
-logging.basicConfig(format='%(asctime)s %(levelname)s (%(name)s): %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S%z', level=properties.LOG_LEVEL)
-logger = logging.getLogger('poll_manager')
+cwd = os.path.dirname(os.path.realpath(__file__))
+logfile = cwd + "/poll_manager.log"
+daiquiri.setup(level=logging.INFO,
+               outputs=(daiquiri.output.File(logfile), "stdout",))
+logger = daiquiri.getLogger(__name__)
 
 
 def bootstrap(url=None):

--- a/src/queue_manager.py
+++ b/src/queue_manager.py
@@ -13,11 +13,9 @@
 :Created:
     3/2/17
 """
-
 import os
-import logging
-from datetime import datetime
 
+import daiquiri
 from sqlalchemy import Column, Integer, String, DateTime, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -27,10 +25,10 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
-from package import Package
 import properties
 
-logger = logging.getLogger('adapter_db')
+
+logger = daiquiri.getLogger(__name__)
 
 Base = declarative_base()
 


### PR DESCRIPTION
The daiquiri logging interface provides a number of features that make it easier to use than the default Python logger. This merge incorporates the daiquiri logger into the pastaplus_adapter3 code base.